### PR TITLE
Fix capitalization issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           target: test-images/
           dimensions: 50%
           widthLimit: 1024
-          HeightLimit: 768
+          heightLimit: 768
 
       - name: Verify results
         run: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This action uses `mogrify` at its core for resizing.
 
 To understand more about the tool and how to define dimensions read this [guide on mogrify](https://imagemagick.org/script/mogrify.php)
 
-### Resize paremeter
+### Resize parameter
 
 The `dimensions` parameter is passed to the command line for the [resize cli option for mogrify](https://imagemagick.org/script/command-line-options.php#resize).
 
@@ -32,7 +32,7 @@ Some examples:
 
 ### Sample usage
 
-Since Github actions can be built together, you could put several steps together to do the following:
+Since GitHub Actions can be built together, you could put several steps together to do the following:
 
 * Resize images on pull-request above 1024 width and 768 height
 * Reduce them to 90%
@@ -72,7 +72,7 @@ jobs:
           author_name: "github-actions[bot]"
           author_email: "github-actions@users.noreply.github.com"
           message: |
-            Images Reszied by Github action\n
+            Images Resized by GitHub Actions\n
             ```
             ${{steps.resize-images.outputs.images_changed}}
             ```
@@ -92,7 +92,7 @@ You should then see something like this:
 
 ![PR Comment](https://user-images.githubusercontent.com/1064715/93666213-34f76400-fa74-11ea-8baa-5ca35636e923.png)
 
-I also made a Github action to convert CSV into markdown, so you can take the CSV output and post it to the pull-request as a Markdown table:
+I also made a GitHub Action to convert CSV into markdown, so you can take the CSV output and post it to the pull-request as a Markdown table:
 
 ```yaml
 name: Resize images
@@ -128,7 +128,7 @@ jobs:
           author_name: "github-actions[bot]"
           author_email: "github-actions@users.noreply.github.com"
           message: |
-            Images Reszied by Github action\n
+            Images Resized by GitHub Actions\n
             ```
             ${{steps.resize-images.outputs.images_changed}}
             ```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
   widthLimit:
     description: 'Width Limit'
     required: true
-  HeightLimit:
+  heightLimit:
     description: 'Height Limit'
     required: true
 outputs:
@@ -30,7 +30,7 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.widthLimit }}
-    - ${{ inputs.HeightLimit }}
+    - ${{ inputs.heightLimit }}
     - ${{ inputs.target }}
     - ${{ inputs.dimensions }}
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ for f in "${imagearray[@]}"; do
 
   if [ "$imageWidth" -gt "$limitWidth" ] || [ "$imageHeight" -gt "$limitHeight" ]; then
     echo "Image $f is Oversized: $imageWidth x $imageHeight"
-    echo "mogrifying comand will be: mogrify -resize $resizeparam $f"
+    echo "mogrifying command will be: mogrify -resize $resizeparam $f"
     mogrify -resize "$resizeparam" "$f"
     newimageWidth=$(identify -format "%w" "$f")
     newimageHeight=$(identify -format "%h" "$f")

--- a/spec/integration/github_action_integration_spec.rb
+++ b/spec/integration/github_action_integration_spec.rb
@@ -30,12 +30,12 @@ describe 'GitHub Action Integration Tests' do
       expect(inputs).to have_key('target')
       expect(inputs).to have_key('dimensions')
       expect(inputs).to have_key('widthLimit')
-      expect(inputs).to have_key('HeightLimit')
+      expect(inputs).to have_key('heightLimit')
 
       expect(inputs['target']['required']).to be true
       expect(inputs['dimensions']['required']).to be true
       expect(inputs['widthLimit']['required']).to be true
-      expect(inputs['HeightLimit']['required']).to be true
+      expect(inputs['heightLimit']['required']).to be true
     end
 
     it 'has correct output definitions' do


### PR DESCRIPTION
- Fixed typo: 'Reszied' -> 'Resized' in commit messages
- Fixed 'Github' -> 'GitHub' throughout documentation
- Fixed 'Github action' -> 'GitHub Actions' for consistency
- Fixed 'paremeter' -> 'parameter' in README
- Fixed 'comand' -> 'command' in entrypoint.sh
- Fixed inconsistent capitalization of 'HeightLimit' -> 'heightLimit' in action.yml

These changes address the capitalization issues mentioned in GitHub issue #3.